### PR TITLE
preload strings to ints

### DIFF
--- a/src/net/unknownuser/ansi/ANSICodes.java
+++ b/src/net/unknownuser/ansi/ANSICodes.java
@@ -4,82 +4,84 @@ public enum ANSICodes {
 	// https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 	
 	// simply no style at all
-	NONE(""),
+	NONE(0),
 	
 	// resets all attributes
-	ALL_RESET("\u001B[0m"),
+	ALL_RESET(0),
 	
 	// all foreground colours
-	COLOUR_FOREGROUND_BLACK("\u001B[30m"),
-	COLOUR_FOREGROUND_RED("\u001B[31m"),
-	COLOUR_FOREGROUND_GREEN("\u001B[32m"),
-	COLOUR_FOREGROUND_YELLOW("\u001B[33m"),
-	COLOUR_FOREGROUND_BLUE("\u001B[34m"),
-	COLOUR_FOREGROUND_PURPLE("\u001B[35m"),
-	COLOUR_FOREGROUND_CYAN("\u001B[36m"),
-	COLOUR_FOREGROUND_WHITE("\u001B[37m"),
+	COLOUR_FOREGROUND_BLACK(30),
+	COLOUR_FOREGROUND_RED(31),
+	COLOUR_FOREGROUND_GREEN(32),
+	COLOUR_FOREGROUND_YELLOW(33),
+	COLOUR_FOREGROUND_BLUE(34),
+	COLOUR_FOREGROUND_PURPLE(35),
+	COLOUR_FOREGROUND_CYAN(36),
+	COLOUR_FOREGROUND_WHITE(37),
 	
-	COLOUR_FOREGROUND_BRIGHT_BLACK("\u001B[90m"),
-	COLOUR_FOREGROUND_BRIGHT_RED("\u001B[91m"),
-	COLOUR_FOREGROUND_BRIGHT_GREEN("\u001B[92m"),
-	COLOUR_FOREGROUND_BRIGHT_YELLOW("\u001B[93m"),
-	COLOUR_FOREGROUND_BRIGHT_BLUE("\u001B[94m"),
-	COLOUR_FOREGROUND_BRIGHT_PURPLE("\u001B[95m"),
-	COLOUR_FOREGROUND_BRIGHT_CYAN("\u001B[96m"),
-	COLOUR_FOREGROUND_BRIGHT_WHITE("\u001B[97m"),
+	COLOUR_FOREGROUND_BRIGHT_BLACK(90),
+	COLOUR_FOREGROUND_BRIGHT_RED(91),
+	COLOUR_FOREGROUND_BRIGHT_GREEN(92),
+	COLOUR_FOREGROUND_BRIGHT_YELLOW(93),
+	COLOUR_FOREGROUND_BRIGHT_BLUE(94),
+	COLOUR_FOREGROUND_BRIGHT_PURPLE(95),
+	COLOUR_FOREGROUND_BRIGHT_CYAN(96),
+	COLOUR_FOREGROUND_BRIGHT_WHITE(97),
 	
 	// all background colours
-	COLOUR_BACKROUND_BLACK("\u001B[40m"),
-	COLOUR_BACKROUND_RED("\u001B[41m"),
-	COLOUR_BACKROUND_GREEN("\u001B[42m"),
-	COLOUR_BACKROUND_YELLOW("\u001B[43m"),
-	COLOUR_BACKROUND_BLUE("\u001B[44m"),
-	COLOUR_BACKROUND_PURPLE("\u001B[45m"),
-	COLOUR_BACKROUND_CYAN("\u001B[46m"),
-	COLOUR_BACKROUND_WHITE("\u001B[47m"),
+	COLOUR_BACKROUND_BLACK(40),
+	COLOUR_BACKROUND_RED(41),
+	COLOUR_BACKROUND_GREEN(42),
+	COLOUR_BACKROUND_YELLOW(43),
+	COLOUR_BACKROUND_BLUE(44),
+	COLOUR_BACKROUND_PURPLE(45),
+	COLOUR_BACKROUND_CYAN(46),
+	COLOUR_BACKROUND_WHITE(47),
 	
-	COLOUR_BACKROUND_BRIGHT_BLACK("\u001B[100m"),
-	COLOUR_BACKROUND_BRIGHT_RED("\u001B[101m"),
-	COLOUR_BACKROUND_BRIGHT_GREEN("\u001B[102m"),
-	COLOUR_BACKROUND_BRIGHT_YELLOW("\u001B[103m"),
-	COLOUR_BACKROUND_BRIGHT_BLUE("\u001B[104m"),
-	COLOUR_BACKROUND_BRIGHT_PURPLE("\u001B[105m"),
-	COLOUR_BACKROUND_BRIGHT_CYAN("\u001B[106m"),
-	COLOUR_BACKROUND_BRIGHT_WHITE("\u001B[107m"),
+	COLOUR_BACKROUND_BRIGHT_BLACK(100),
+	COLOUR_BACKROUND_BRIGHT_RED(101),
+	COLOUR_BACKROUND_BRIGHT_GREEN(102),
+	COLOUR_BACKROUND_BRIGHT_YELLOW(103),
+	COLOUR_BACKROUND_BRIGHT_BLUE(104),
+	COLOUR_BACKROUND_BRIGHT_PURPLE(105),
+	COLOUR_BACKROUND_BRIGHT_CYAN(106),
+	COLOUR_BACKROUND_BRIGHT_WHITE(107),
 	
 	// various styles
-	STYLE_BOLD("\u001B[1m"),
-	STYLE_ITALIC("\u001B[3m"),
-	STYLE_UNDERLINE("\u001B[4m"),
-	STYLE_INVERT("\u001B[7m"),
-	STYLE_HIDE("\u001B[8m"),
-	STYLE_STRIKETHROUGH("\u001B[9m"),
-	STYLE_DOUBLE_UNDERLINE("\u001B[21m"),
-	STYLE_FRAMED("\u001B[51m"),
+	STYLE_BOLD(1),
+	STYLE_ITALIC(3),
+	STYLE_UNDERLINE(4),
+	STYLE_INVERT(7),
+	STYLE_HIDE(8),
+	STYLE_STRIKETHROUGH(9),
+	STYLE_DOUBLE_UNDERLINE(21),
+	STYLE_FRAMED(51),
 	
 	// other styles
-	STYLE_NORMAL_INTENSITY("\u001B[22m"),
-	STYLE_NOT_ITALIC_OR_BLACKLETTER("\u001B[23m"),
-	STYLE_NOT_UNDERLINED("\u001B[24m"),
-	STYLE_BLINK_SLOW("\u001B[5m"),
-	STYLE_BLINK_FAST("\u001B[6m"),
-	STYLE_NOT_BLINKING("\u001B[25m"),
-	STYLE_NOT_REVERSED("\u001B[27m"),
-	STYLE_REVEALED("\u001B[28m"), // undo hide
-	STYLE_NOT_CROSSED("\u001B[29m"),
-	STYLE_NOT_FRAMED_OR_ENCIRCLED("\u001B[54m"),
+	STYLE_NORMAL_INTENSITY(22),
+	STYLE_NOT_ITALIC_OR_BLACKLETTER(23),
+	STYLE_NOT_UNDERLINED(24),
+	STYLE_BLINK_SLOW(5),
+	STYLE_BLINK_FAST(6),
+	STYLE_NOT_BLINKING(25),
+	STYLE_NOT_REVERSED(27),
+	STYLE_REVEALED(28), // undo hide
+	STYLE_NOT_CROSSED(29),
+	STYLE_NOT_FRAMED_OR_ENCIRCLED(54),
 	
 	// untested
-	STYLE_FAINT("\u001B[2m"),
-	STYLE_FRAKTUR("\u001B[20m"),
-	STYLE_ENCIRCLED("\u001B[52m"),
-	STYLE_OVERLINE("\u001B[53m");
+	STYLE_FAINT(2),
+	STYLE_FRAKTUR(20),
+	STYLE_ENCIRCLED(52),
+	STYLE_OVERLINE(53);
 	
-	private final String code;
+	private final String escapeCodeDefault = "\u001B[%sm";
+	
+	private final int codeNumber;
 	private static boolean enabled = true;
 	
-	private ANSICodes(String code) {
-		this.code = code;
+	private ANSICodes(int code) {
+		this.codeNumber = code;
 	}
 	
 	/**
@@ -102,14 +104,13 @@ public enum ANSICodes {
 	}
 	
 	/**
-	 * Returns the code for the given code. Output has to have the capability to display ANSI
-	 * formatted text.
+	 * Returns the escape sequence for the given code.
 	 * 
 	 * @return The Unicode character for the given format.
 	 */
 	public String getCode() {
 		if(enabled) {
-			return this.code;
+			return String.format(escapeCodeDefault, codeNumber);
 		} else {
 			return "";
 		}
@@ -123,7 +124,7 @@ public enum ANSICodes {
 	 * @see ANSICodes#getCode()
 	 */
 	public int getCodeNumber() {
-		return Integer.parseInt(getCode().substring(getCode().indexOf("[") + 1, getCode().indexOf("m")));
+		return codeNumber;
 	}
 	
 	/**
@@ -141,9 +142,15 @@ public enum ANSICodes {
 		}
 	}
 	
-	public static String multiModeString(String text, ANSICodes... codes) {
-		if(!enabled) {
-			return text;
+	/**
+	 * Creates an escape code for multiple styles at once. Some special combinations may not work properly.
+	 * 
+	 * @param codes
+	 * @return
+	 */
+	public static String multiStyle(ANSICodes... codes) {
+		if(!enabled || codes.length == 0) {
+			return "";
 		}
 		
 		StringBuilder sb = new StringBuilder();
@@ -154,7 +161,7 @@ public enum ANSICodes {
 		}
 		sb.deleteCharAt(sb.length() - 1);
 		
-		sb.append("m" + text + ALL_RESET);
+		sb.append("m");
 		
 		return sb.toString();
 	}
@@ -170,6 +177,24 @@ public enum ANSICodes {
 	}
 	
 	/**
+	 * Formats an escape sequence to display a custom 24 bit colour. Essentially a standard
+	 * RGB colour.
+	 * 
+	 * @param r The red intensity
+	 * @param g The green intensity
+	 * @param b The blue intensity
+	 * @param isBackground Whether the colour should be for the background
+	 * @return The ANSI sequence for the given colour. An empty string if any number is invalid.
+	 */
+	public static String get24BitColour(int r, int g, int b, boolean isBackground) {
+		if(!enabled || !is8Bit(r) || !is8Bit(g) || !is8Bit(b)) {
+			return "";
+		}
+		
+		return String.format("\u001B[%d;2;%d;%d;%dm",(isBackground ? 48 : 38) , r, g, b);
+	}
+	
+	/**
 	 * Formats an escape sequence to display a custom 24 bit foreground colour. Essentially a standard
 	 * RGB colour.
 	 * 
@@ -178,29 +203,31 @@ public enum ANSICodes {
 	 * @param b The blue intensity
 	 * @return The ANSI sequence for the given colour. An empty string if any number is invalid.
 	 */
-	public static String get24BitForegroundColour(int r, int g, int b) {
-		if(!enabled || !is8Bit(r) || !is8Bit(g) || !is8Bit(b)) {
-			return "";
-		}
-		
-		return String.format("\u001B[38;2;%d;%d;%dm", r, g, b);
+	public static String get24BitColour(int r, int g, int b) {
+		return get24BitColour(r, g, b, false);
 	}
 	
 	/**
-	 * Formats an escape sequence to display a custom 24 bit background colour. Essentially a standard
-	 * RGB colour.
+	 * Returns an escape sequence for the given colour on the standard ANSI colour table.<br>
+	 * The codes are:
 	 * 
-	 * @param r The red intensity
-	 * @param g The green intensity
-	 * @param b The blue intensity
+	 * <pre>
+	 *   0 -   7: standard colours
+	 *   8 -  15: high intensity or bright colours
+	 *  16 - 231: colours on a 6x6x6 colour cube
+	 * 232 - 255: grey colours, smaller number means darker grey</pre>
+	 * 
+	 * @param id The pre defined colour number
+	 * @param isBackground Whether the colour should be for the background
 	 * @return The ANSI sequence for the given colour. An empty string if any number is invalid.
+	 * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit">The colour codes for each id</a>
 	 */
-	public static String get24BitBackgroundColour(int r, int g, int b) {
-		if(!enabled || !is8Bit(r) || !is8Bit(g) || !is8Bit(b)) {
+	public static String get8BitColour(int id, boolean isBackgorund) {
+		if(!enabled || !is8Bit(id)) {
 			return "";
 		}
 		
-		return String.format("\u001B[48;2;%d;%d;%dm", r, g, b);
+		return String.format("\u001B[%d;5;%dm", (isBackgorund ? 48 : 38), id);
 	}
 	
 	/**
@@ -217,35 +244,8 @@ public enum ANSICodes {
 	 * @return The ANSI sequence for the given colour. An empty string if any number is invalid.
 	 * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit">The colour codes for each id</a>
 	 */
-	public static String get8BitForegroundColour(int id) {
-		if(!enabled || !is8Bit(id)) {
-			return "";
-		}
-		
-		return String.format("\u001B[38;5;%dm", id);
-	}
-	
-	/**
-	 * Returns an escape sequence for the given colour on the standard ANSI colour table.<br>
-	 * The codes are:
-	 * 
-	 * <pre>
-	 *   0 -   7: standard colours
-	 *   8 -  15: high intensity or bright colours
-	 *  16 - 231: colours on a 6x6x6 colour cube
-	 * 232 - 255: grey colours, smaller number means darker grey
-	 * </pre>
-	 * 
-	 * @param id The pre defined colour number
-	 * @return The ANSI sequence for the given colour. An empty string if any number is invalid.
-	 * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit">The colour codes for each id</a>
-	 */
-	public static String get8BitBackgroundColour(int id) {
-		if(!enabled || !is8Bit(id)) {
-			return "";
-		}
-		
-		return String.format("\u001B[48;5;%dm", id);
+	public static String get8BitColour(int id) {
+		return get8BitColour(id, false);
 	}
 	
 	@Override


### PR DESCRIPTION
changed the pre-defined escape codes to ints, reducing heap usage
methods are redone to reduce redundancy while retaining functionality